### PR TITLE
update aws sdk dependency version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -63,7 +63,8 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.3.26</version>
+            <version>1.7.1</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I've just updated aws sdk to newer version. This looks working. Also we provide our own aws sdk jar, so I've changed scope to `provided`.

@dbarashev review?
