### PR TITLE
Empty id in findById query

### DIFF
--- a/core/src/main/java/com/spaceprogram/simplejpa/DomainHelper.java
+++ b/core/src/main/java/com/spaceprogram/simplejpa/DomainHelper.java
@@ -158,7 +158,7 @@ public class DomainHelper {
      */
     public static Item findItemById(AmazonSimpleDB db, String domainName, String itemName, boolean consistentRead) throws AmazonClientException {
         if (itemName.isEmpty()) {
-          throw new PersistenceException("Empty item name");
+          return null;
         }
         GetAttributesResult results = db.getAttributes(new GetAttributesRequest()
             .withConsistentRead(consistentRead)

--- a/core/src/main/java/com/spaceprogram/simplejpa/DomainHelper.java
+++ b/core/src/main/java/com/spaceprogram/simplejpa/DomainHelper.java
@@ -11,6 +11,8 @@ import com.amazonaws.services.simpledb.model.Item;
 import com.amazonaws.services.simpledb.model.SelectRequest;
 import com.amazonaws.services.simpledb.model.SelectResult;
 
+import javax.persistence.PersistenceException;
+
 /**
  * This is a utility class for doing SimpleDB queries.
  *
@@ -155,7 +157,9 @@ public class DomainHelper {
      * @throws AmazonClientException
      */
     public static Item findItemById(AmazonSimpleDB db, String domainName, String itemName, boolean consistentRead) throws AmazonClientException {
-
+        if (itemName.isEmpty()) {
+          throw new PersistenceException("Empty item name");
+        }
         GetAttributesResult results = db.getAttributes(new GetAttributesRequest()
             .withConsistentRead(consistentRead)
             .withDomainName(domainName)
@@ -164,8 +168,6 @@ public class DomainHelper {
         if(results.getAttributes().size() == 0) {
             return null;
         }
-        
-        Item item = new Item(itemName, results.getAttributes());
-        return item;        
+      return new Item(itemName, results.getAttributes());        
     }	
 }

--- a/core/src/main/java/com/spaceprogram/simplejpa/EntityManagerSimpleJPA.java
+++ b/core/src/main/java/com/spaceprogram/simplejpa/EntityManagerSimpleJPA.java
@@ -214,10 +214,12 @@ public class EntityManagerSimpleJPA implements SimpleEntityManager, DatabaseMana
      * @return
      */
     public <T> T find(Class<T> tClass, Object id) {
-        if (!sessionless && closed)
-            throw new PersistenceException("EntityManager already closed.");
-        if (id == null)
-            throw new IllegalArgumentException("Id value must not be null.");
+        if (!sessionless && closed) {
+          throw new PersistenceException("EntityManager already closed.");
+        }
+        if (id == null || id.equals("")) {
+          throw new IllegalArgumentException("Id value must not be null or empty.");
+        }
         try {
             T ob = cacheGet(tClass, id);
             if (ob != null) {
@@ -237,7 +239,6 @@ public class EntityManagerSimpleJPA implements SimpleEntityManager, DatabaseMana
         if (domainName == null)
             return null;
         Item iraw = DomainHelper.findItemById(factory.getSimpleDb(), domainName, id.toString(), consistentRead);
-// logger.fine("got back item=" + item);
         if (iraw == null)
             return null;
         SdbItem item = new SdbItemImpl2(iraw);

--- a/core/src/main/java/com/spaceprogram/simplejpa/EntityManagerSimpleJPA.java
+++ b/core/src/main/java/com/spaceprogram/simplejpa/EntityManagerSimpleJPA.java
@@ -217,7 +217,7 @@ public class EntityManagerSimpleJPA implements SimpleEntityManager, DatabaseMana
         if (!sessionless && closed) {
           throw new PersistenceException("EntityManager already closed.");
         }
-        if (id == null || id.equals("")) {
+        if (id == null) {
           throw new IllegalArgumentException("Id value must not be null or empty.");
         }
         try {

--- a/core/src/test/java/com/spaceprogram/simplejpa/DomainHelperTests.java
+++ b/core/src/test/java/com/spaceprogram/simplejpa/DomainHelperTests.java
@@ -47,13 +47,7 @@ public class DomainHelperTests extends BaseTestClass {
                 .withDomainName(DOMAIN_NAME)
                 .withAttributes(new ReplaceableAttribute("name", "value", true)));
         Assert.assertNotNull(DomainHelper.findItemById(mySdbClient, DOMAIN_NAME, "exist"));
-
-        try {
-            DomainHelper.findItemById(mySdbClient, DOMAIN_NAME, "");
-            Assert.fail("Exception expected");
-        } catch (PersistenceException e) {
-            // OK, got an exception
-        }
+        Assert.assertNull(DomainHelper.findItemById(mySdbClient, DOMAIN_NAME, ""));
     }
 
     @Test

--- a/core/src/test/java/com/spaceprogram/simplejpa/papeeria/BasePapeeriaTest.java
+++ b/core/src/test/java/com/spaceprogram/simplejpa/papeeria/BasePapeeriaTest.java
@@ -1,0 +1,58 @@
+package com.spaceprogram.simplejpa.papeeria;
+
+import com.amazonaws.services.simpledb.AmazonSimpleDB;
+import com.amazonaws.services.simpledb.model.DeleteDomainRequest;
+import com.spaceprogram.simplejpa.EntityManagerFactoryImpl;
+import com.spaceprogram.simplejpa.EntityManagerSimpleJPA;
+import junit.framework.TestCase;
+import org.junit.Ignore;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author gkalabin@papeeria.com
+ */
+@Ignore
+public class BasePapeeriaTest extends TestCase {
+    public static final String PERSISTENCE_UNIT_NAME = "papeeriatestunit";
+    private EntityManagerFactoryImpl myEntityManagerFactory;
+
+    protected static final List<Class<?>> ourTestClasses = new ArrayList<Class<?>>();
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myEntityManagerFactory = new EntityManagerFactoryImpl(PERSISTENCE_UNIT_NAME, null, null, getStringClassNames());
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        super.tearDown();
+        EntityManagerSimpleJPA em = (EntityManagerSimpleJPA) myEntityManagerFactory.createEntityManager();
+        for (Class<?> aClass : ourTestClasses) {
+            AmazonSimpleDB db = em.getSimpleDb();
+            String domainName = em.getDomainName(aClass);
+
+            System.out.println("deleting domain: " + domainName);
+            DeleteDomainRequest deleteDomainRequest = new DeleteDomainRequest(domainName);
+            db.deleteDomain(deleteDomainRequest);
+        }
+        em.close();
+    }
+
+    protected Set<String> getStringClassNames() {
+        Set<String> classNames = new HashSet<String>(ourTestClasses.size());
+        for (Class aClass : ourTestClasses) {
+            classNames.add(aClass.getName());
+        }
+        return classNames;
+    }
+
+    protected EntityManager getEntityManager() {
+        return myEntityManagerFactory.createEntityManager();
+    }
+}

--- a/core/src/test/java/com/spaceprogram/simplejpa/papeeria/BooleanObjectBuilderTest.java
+++ b/core/src/test/java/com/spaceprogram/simplejpa/papeeria/BooleanObjectBuilderTest.java
@@ -1,38 +1,21 @@
 package com.spaceprogram.simplejpa.papeeria;
 
-import com.amazonaws.services.simpledb.AmazonSimpleDB;
-import com.amazonaws.services.simpledb.model.DeleteDomainRequest;
-import com.spaceprogram.simplejpa.EntityManagerFactoryImpl;
-import com.spaceprogram.simplejpa.EntityManagerSimpleJPA;
 import com.spaceprogram.simplejpa.papeeria.models.BooleanBox;
-import junit.framework.TestCase;
 
 import javax.persistence.EntityManager;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * @author gkalabin@papeeria.com
  */
-public class BooleanObjectBuilderTest extends TestCase {
-  public static final String PERSISTENCE_UNIT_NAME = "papeeriatestunit";
-  private EntityManagerFactoryImpl myEntityManagerFactory;
-
-  private static final List<Class<?>> CLASSES = new ArrayList<Class<?>>();
-
+public class BooleanObjectBuilderTest extends BasePapeeriaTest {
   static {
-    CLASSES.add(BooleanBox.class);
+    ourTestClasses.add(BooleanBox.class);
   }
-
 
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    myEntityManagerFactory = new EntityManagerFactoryImpl(PERSISTENCE_UNIT_NAME, null, null, getStringClassNames());
-
-    EntityManager em = myEntityManagerFactory.createEntityManager();
+    EntityManager em = getEntityManager();
     {
       // create initial structure
       em.persist(new BooleanBox("t1", true));
@@ -41,30 +24,15 @@ public class BooleanObjectBuilderTest extends TestCase {
     }
   }
 
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
-    EntityManagerSimpleJPA em = (EntityManagerSimpleJPA) myEntityManagerFactory.createEntityManager();
-    for (Class<?> aClass : CLASSES) {
-      AmazonSimpleDB db = em.getSimpleDb();
-      String domainName = em.getDomainName(aClass);
-
-      System.out.println("deleting domain: " + domainName);
-      DeleteDomainRequest deleteDomainRequest = new DeleteDomainRequest(domainName);
-      db.deleteDomain(deleteDomainRequest);
-    }
-    em.close();
-  }
-
   public void testSameObjects() {
     BooleanBox t1, anotherT1;
     {
-      EntityManager em = myEntityManagerFactory.createEntityManager();
+      EntityManager em = getEntityManager();
       t1 = em.find(BooleanBox.class, "t1");
       em.close();
     }
     {
-      EntityManager em = myEntityManagerFactory.createEntityManager();
+      EntityManager em = getEntityManager();
       anotherT1 = em.find(BooleanBox.class, "t1");
       em.close();
     }
@@ -76,25 +44,17 @@ public class BooleanObjectBuilderTest extends TestCase {
   public void testSameObjectFields() {
     BooleanBox t1, t2;
     {
-      EntityManager em = myEntityManagerFactory.createEntityManager();
+      EntityManager em = getEntityManager();
       t1 = em.find(BooleanBox.class, "t1");
       em.close();
     }
     {
-      EntityManager em = myEntityManagerFactory.createEntityManager();
+      EntityManager em = getEntityManager();
       t2 = em.find(BooleanBox.class, "t2");
       em.close();
     }
     assertTrue(t1.getBooleanObject());
     assertTrue(t2.getBooleanObject());
     assertTrue(t1.getBooleanObject() == t2.getBooleanObject());
-  }
-
-  private Set<String> getStringClassNames() {
-    Set<String> classNames = new HashSet<String>(CLASSES.size());
-    for (Class aClass : CLASSES) {
-      classNames.add(aClass.getName());
-    }
-    return classNames;
   }
 }

--- a/core/src/test/java/com/spaceprogram/simplejpa/papeeria/query/AbstractQueryTests.java
+++ b/core/src/test/java/com/spaceprogram/simplejpa/papeeria/query/AbstractQueryTests.java
@@ -1,66 +1,34 @@
 package com.spaceprogram.simplejpa.papeeria.query;
 
-import com.amazonaws.services.simpledb.AmazonSimpleDB;
-import com.amazonaws.services.simpledb.model.DeleteDomainRequest;
-import com.spaceprogram.simplejpa.EntityManagerFactoryImpl;
-import com.spaceprogram.simplejpa.EntityManagerSimpleJPA;
+import com.spaceprogram.simplejpa.papeeria.BasePapeeriaTest;
 import com.spaceprogram.simplejpa.papeeria.models.PrimitiveBox;
-import junit.framework.TestCase;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
- * @author gkalabin@bardsoftware.com
+ * @author gkalabin@papeeria.com
  */
-public class AbstractQueryTests extends TestCase {
-  public static final String PERSISTENCE_UNIT_NAME = "papeeriatestunit";
-  private EntityManagerFactoryImpl myEntityManagerFactory;
-
-  private static final List<Class<?>> CLASSES = new ArrayList<Class<?>>();
-
+public class AbstractQueryTests extends BasePapeeriaTest {
   static {
-    CLASSES.add(PrimitiveBox.class);
+    ourTestClasses.add(PrimitiveBox.class);
   }
-
 
   @Override
   protected void setUp() throws Exception {
     super.setUp();
-    myEntityManagerFactory = new EntityManagerFactoryImpl(PERSISTENCE_UNIT_NAME, null, null, getStringClassNames());
-
-    EntityManager em = myEntityManagerFactory.createEntityManager();
-    {
-      // create initial structure
-      PrimitiveBox obj = new PrimitiveBox("foo", 42, 115L, .5d);
-      PrimitiveBox obj2 = new PrimitiveBox("bar", 24, 511L, 5.5d);
-      em.persist(obj);
-      em.persist(obj2);
-      em.close();
-    }
-  }
-
-  @Override
-  protected void tearDown() throws Exception {
-    super.tearDown();
-    EntityManagerSimpleJPA em = (EntityManagerSimpleJPA) myEntityManagerFactory.createEntityManager();
-    for (Class<?> aClass : CLASSES) {
-      AmazonSimpleDB db = em.getSimpleDb();
-      String domainName = em.getDomainName(aClass);
-
-      System.out.println("deleting domain: " + domainName);
-      DeleteDomainRequest deleteDomainRequest = new DeleteDomainRequest(domainName);
-      db.deleteDomain(deleteDomainRequest);
-    }
+    EntityManager em = getEntityManager();
+    // create initial structure
+    PrimitiveBox obj = new PrimitiveBox("foo", 42, 115L, .5d);
+    PrimitiveBox obj2 = new PrimitiveBox("bar", 24, 511L, 5.5d);
+    em.persist(obj);
+    em.persist(obj2);
     em.close();
   }
 
   public void testQueryWithIntParam() {
-    EntityManager em = myEntityManagerFactory.createEntityManager();
+    EntityManager em = getEntityManager();
     Query query = em.createQuery("SELECT b FROM PrimitiveBox b WHERE b.int=:int");
     query.setParameter("int", 42);
     List<PrimitiveBox> resultList = query.getResultList();
@@ -72,7 +40,7 @@ public class AbstractQueryTests extends TestCase {
   }
 
   public void testQueryWithLongParam() {
-    EntityManager em = myEntityManagerFactory.createEntityManager();
+    EntityManager em = getEntityManager();
     Query query = em.createQuery("SELECT b FROM PrimitiveBox b WHERE b.long<>:long");
     query.setParameter("long", 511L);
     List<PrimitiveBox> resultList = query.getResultList();
@@ -84,7 +52,7 @@ public class AbstractQueryTests extends TestCase {
   }
 
   public void testQueryWithDoubleParam() {
-    EntityManager em = myEntityManagerFactory.createEntityManager();
+    EntityManager em = getEntityManager();
     Query query = em.createQuery("SELECT b FROM PrimitiveBox b WHERE b.double=:double");
     query.setParameter("double", .5d);
     List<PrimitiveBox> resultList = query.getResultList();
@@ -93,13 +61,5 @@ public class AbstractQueryTests extends TestCase {
     assertEquals(115L, resultList.get(0).getLong());
     assertEquals(.5d, resultList.get(0).getDouble());
     em.close();
-  }
-
-  private Set<String> getStringClassNames() {
-    Set<String> classNames = new HashSet<String>(CLASSES.size());
-    for (Class aClass : CLASSES) {
-      classNames.add(aClass.getName());
-    }
-    return classNames;
   }
 }


### PR DESCRIPTION
Amazon doesn't support empty item names and it throws an exception in such case. Here we don't send find by id query with empty item name.

@dbarashev  review?
